### PR TITLE
fix(consumer): timeouts

### DIFF
--- a/src/data_collection/app/config.py
+++ b/src/data_collection/app/config.py
@@ -10,7 +10,7 @@ from pydantic import (
     Field,
     root_validator,
     PostgresDsn,
-    RedisDsn
+    RedisDsn,
 )
 
 from app.model.producer_type import ProducerType

--- a/src/data_collection/app/consumer.py
+++ b/src/data_collection/app/consumer.py
@@ -5,7 +5,7 @@ from web3.types import TxReceipt, HexBytes
 
 from app import init_logger
 from app.config import Config
-from app.kafka.exceptions import KafkaConsumerTopicEmptyError
+from app.kafka.exceptions import KafkaConsumerPartitionsEmptyError
 from app.kafka.manager import KafkaConsumerManager
 from app.model.abi import ContractABI
 from app.model.contract import ContractCategory
@@ -302,7 +302,7 @@ class DataConsumer(DataCollector):
             await self.kafka_manager.start_consuming(
                 on_event_callback=self._on_kafka_event
             )
-        except KafkaConsumerTopicEmptyError:
+        except KafkaConsumerPartitionsEmptyError:
             # Raised when a partition doesn't receive a new message for 120 seconds.
             log.info(f"Finished processing topic '{self.kafka_manager.topic}'.")
             # exit_code doesn't change, 0 = success

--- a/src/data_collection/app/kafka/exceptions.py
+++ b/src/data_collection/app/kafka/exceptions.py
@@ -4,8 +4,8 @@ class KafkaManagerError(Exception):
     pass
 
 
-class KafkaConsumerTopicEmptyError(KafkaManagerError):
-    """Raised when a message is not retrieved from a topic for a some time."""
+class KafkaConsumerPartitionsEmptyError(KafkaManagerError):
+    """Raised when a message is not retrieved from any partition for a some time."""
 
     pass
 

--- a/src/data_collection/app/web3/node_connector.py
+++ b/src/data_collection/app/web3/node_connector.py
@@ -37,7 +37,7 @@ class NodeConnector:
         self.w3 = Web3(
             provider=Web3.AsyncHTTPProvider(
                 endpoint_uri=node_url,
-                request_kwargs={"headers": headers, "timeout": 60},
+                request_kwargs={"headers": headers, "timeout": 600},
             ),
             modules={
                 "eth": (AsyncEth,),

--- a/src/data_collection/etc/cfg/prod/eth.json
+++ b/src/data_collection/etc/cfg/prod/eth.json
@@ -8,7 +8,7 @@
         {
             "producer_type": "full",
             "start_block": 15500000,
-            "end_block": 15501000,
+            "end_block": 15500002,
             "contracts": [
                 {
                     "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",

--- a/src/data_collection/scripts/wait-for-db.sh
+++ b/src/data_collection/scripts/wait-for-db.sh
@@ -3,7 +3,7 @@
 RETRIES=0
 
 # Wait for PostgreSQL to start
-while ! curl http://$POSTGRES_HOST:$POSTGRES_PORT/ 2>&1 | grep '52';
+while ! curl --connect-timeout 5 http://$POSTGRES_HOST:$POSTGRES_PORT/ 2>&1 | grep '52';
 do
   sleep 1;
   echo "Waiting 1s for PostgreSQL container to start.";

--- a/src/data_collection/scripts/wait-for-kafka.sh
+++ b/src/data_collection/scripts/wait-for-kafka.sh
@@ -6,7 +6,7 @@ MAX_RETRIES=40
 echo "Waiting for Kafka container to start...";
 
 # Wait for Kafka to start
-while ! curl http://kafka:9092/ 2>&1 | grep '52' >/dev/null;
+while ! curl --connect-timeout 5 http://kafka:9092/ 2>&1 | grep '52' >/dev/null;
 do
   sleep 1;
 


### PR DESCRIPTION
Timeout on empty partition now has a larger timeout (900s) time than timeout on erigon connectivity (600s).

wait-for-kafka.sh and wait-for-db.sh added curl timeout (5s). Resolves